### PR TITLE
Add TheOneProbe recipe progress info provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     deobfCompile 'curse.maven:qmd-362056:3662442'
     deobfCompile 'curse.maven:thaumcraft-223628:2629023'
     deobfCompile 'curse.maven:thaumic-jei-285492:2705304'
+    deobfCompile 'curse.maven:the-one-probe-245211:2667280'
 }
 
 sourceSets {

--- a/src/main/java/com/cleanroommc/multiblocked/Multiblocked.java
+++ b/src/main/java/com/cleanroommc/multiblocked/Multiblocked.java
@@ -1,16 +1,11 @@
 package com.cleanroommc.multiblocked;
 
-import com.cleanroommc.multiblocked.api.json.BlockTypeAdapterFactory;
-import com.cleanroommc.multiblocked.api.json.FluidStackTypeAdapter;
-import com.cleanroommc.multiblocked.api.json.IBlockStateTypeAdapterFactory;
-import com.cleanroommc.multiblocked.api.json.IRendererTypeAdapterFactory;
-import com.cleanroommc.multiblocked.api.json.ItemStackTypeAdapter;
-import com.cleanroommc.multiblocked.api.json.RecipeMapTypeAdapter;
-import com.cleanroommc.multiblocked.api.json.RecipeTypeAdapter;
-import com.cleanroommc.multiblocked.api.json.SimplePredicateFactory;
+import com.cleanroommc.multiblocked.api.json.*;
 import com.cleanroommc.multiblocked.api.recipe.Recipe;
 import com.cleanroommc.multiblocked.api.recipe.RecipeMap;
 import com.cleanroommc.multiblocked.api.tile.BlueprintTableTileEntity;
+import com.cleanroommc.multiblocked.command.CommandClient;
+import com.cleanroommc.multiblocked.integration.InfoProviders;
 import com.cleanroommc.multiblocked.command.CommandMbdTree;
 import com.cleanroommc.multiblocked.jei.JeiPlugin;
 import com.google.gson.Gson;
@@ -24,11 +19,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.event.*;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,6 +46,7 @@ public class Multiblocked {
     public static final String MODID_GEO = "geckolib3";
     public static final String MODID_GTCE = "gregtech";
     public static final String MODID_LC = "lightningcraft";
+    public static final String MODID_TOP = "theoneprobe";
     public static final String NAME = "Multiblocked";
     public static final String VERSION = "0.4.0";
     public static final Logger LOGGER = LogManager.getLogger(NAME);
@@ -105,6 +97,9 @@ public class Multiblocked {
     @EventHandler
     public void init(FMLInitializationEvent event) {
         proxy.init();
+        if (Loader.isModLoaded(MODID_TOP)) {
+            InfoProviders.registerTOP();
+        }
     }
 
     @EventHandler

--- a/src/main/java/com/cleanroommc/multiblocked/integration/InfoProviders.java
+++ b/src/main/java/com/cleanroommc/multiblocked/integration/InfoProviders.java
@@ -1,0 +1,13 @@
+package com.cleanroommc.multiblocked.integration;
+
+import com.cleanroommc.multiblocked.integration.provider.RecipeProgressInfoProvider;
+import mcjty.theoneprobe.TheOneProbe;
+import mcjty.theoneprobe.api.ITheOneProbe;
+
+public class InfoProviders {
+
+    public static void registerTOP() {
+        ITheOneProbe theOneProbe = TheOneProbe.theOneProbeImp;
+        theOneProbe.registerProvider(new RecipeProgressInfoProvider());
+    }
+}

--- a/src/main/java/com/cleanroommc/multiblocked/integration/provider/RecipeProgressInfoProvider.java
+++ b/src/main/java/com/cleanroommc/multiblocked/integration/provider/RecipeProgressInfoProvider.java
@@ -1,0 +1,53 @@
+package com.cleanroommc.multiblocked.integration.provider;
+
+import com.cleanroommc.multiblocked.Multiblocked;
+import com.cleanroommc.multiblocked.api.recipe.RecipeLogic;
+import com.cleanroommc.multiblocked.api.tile.ControllerTileEntity;
+import mcjty.theoneprobe.api.*;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+
+public class RecipeProgressInfoProvider implements IProbeInfoProvider {
+
+    @Override
+    public String getID() {
+        return String.format("%s:recipe_progress_provider", Multiblocked.MODID);
+    }
+
+    @Override
+    public void addProbeInfo(@Nonnull ProbeMode probeMode, @Nonnull IProbeInfo probeInfo, @Nonnull EntityPlayer entityPlayer, @Nonnull World world, @Nonnull IBlockState blockState, @Nonnull IProbeHitData probeHitData) {
+        if (blockState.getBlock().hasTileEntity(blockState)) {
+            TileEntity tileEntity = world.getTileEntity(probeHitData.getPos());
+            if (tileEntity instanceof ControllerTileEntity) {
+                RecipeLogic recipeLogic = ((ControllerTileEntity) tileEntity).getRecipeLogic();
+                if (recipeLogic != null) {
+                    int maxProgress = recipeLogic.duration;
+                    if (maxProgress > 0) {
+                        int currentProgress = recipeLogic.progress;
+                        String text;
+
+                        if (maxProgress < 20) {
+                            // less than 1 second uses ticks
+                            text = String.format(" t / %s t", maxProgress);
+                        } else {
+                            currentProgress = Math.round(currentProgress / 20.0F);
+                            maxProgress = Math.round(maxProgress / 20.0F);
+                            text = String.format(" s / %s s", maxProgress);
+                        }
+
+                        IProbeInfo horizontalPane = probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+                        horizontalPane.text(TextStyleClass.INFO + "{*multiblocked.top.recipe_progress*} ");
+                        horizontalPane.progress(currentProgress, maxProgress, probeInfo.defaultProgressStyle()
+                                .suffix(text)
+                                .filledColor(0xFF4CBB17)
+                                .alternateFilledColor(0xFF4CBB17));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/multiblocked/lang/en_us.lang
+++ b/src/main/resources/assets/multiblocked/lang/en_us.lang
@@ -63,3 +63,4 @@ multiblocked.renderer.tparticle=Textured Particle
 multiblocked.renderer.blockstate=BlockState Model
 multiblocked.renderer.gregtech=GregTech Model
 
+multiblocked.top.recipe_progress=Progress:


### PR DESCRIPTION
Adds a recipe progress info provider for TheOneProbe. This PR adds TOP to the `build.gradle` file, which should also prove useful for testing in the future.