### PR TITLE
Improve Tooltips and Other Info Displays

### DIFF
--- a/src/main/java/com/cleanroommc/multiblocked/api/gui/util/TextFormattingUtil.java
+++ b/src/main/java/com/cleanroommc/multiblocked/api/gui/util/TextFormattingUtil.java
@@ -7,6 +7,7 @@ import java.util.TreeMap;
 public class TextFormattingUtil {
 
     private static final NavigableMap<Long, String> suffixes = new TreeMap<>();
+    private static final NavigableMap<Long, String> suffixesBucket = new TreeMap<>();
 
     static {
         suffixes.put(1_000L, "k");
@@ -15,6 +16,14 @@ public class TextFormattingUtil {
         suffixes.put(1_000_000_000_000L, "T");
         suffixes.put(1_000_000_000_000_000L, "P");
         suffixes.put(1_000_000_000_000_000_000L, "E");
+
+        suffixesBucket.put(1L, "m");
+        suffixesBucket.put(1_000L, "");
+        suffixesBucket.put(1_000_000L, "k");
+        suffixesBucket.put(1_000_000_000L, "M");
+        suffixesBucket.put(1_000_000_000_000L, "G");
+        suffixesBucket.put(1_000_000_000_000_000L, "T");
+        suffixesBucket.put(1_000_000_000_000_000_000L, "P");
     }
 
     public static String formatLongToCompactString(long value, int precision) {
@@ -32,8 +41,19 @@ public class TextFormattingUtil {
         return hasDecimal ? (truncated / 10d) + suffix : (truncated / 10) + suffix;
     }
 
-    public static String formatLongToCompactString(long value) {
-        return formatLongToCompactString(value, 3);
+    public static String formatLongToCompactStringBuckets(long value, int precision) {
+        //Long.MIN_VALUE == -Long.MIN_VALUE so we need an adjustment here
+        if (value == Long.MIN_VALUE) return formatLongToCompactStringBuckets(Long.MIN_VALUE + 1, precision);
+        if (value < 0) return "-" + formatLongToCompactStringBuckets(-value, precision);
+        if (value < Math.pow(10, precision)) return Long.toString(value) + suffixesBucket.floorEntry(value).getValue(); //deal with easy case
+
+        Map.Entry<Long, String> e = suffixesBucket.floorEntry(value);
+        Long divideBy = e.getKey();
+        String suffix = e.getValue();
+
+        long truncated = value / (divideBy / 10); //the number part of the output times 10
+        boolean hasDecimal = truncated < 100 && (truncated / 10d) != (truncated / 10d);
+        return hasDecimal ? (truncated / 10d) + suffix : (truncated / 10) + suffix;
     }
 
 }

--- a/src/main/java/com/cleanroommc/multiblocked/api/gui/widget/imp/TankWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/api/gui/widget/imp/TankWidget.java
@@ -2,11 +2,11 @@ package com.cleanroommc.multiblocked.api.gui.widget.imp;
 
 import com.cleanroommc.multiblocked.api.gui.ingredient.IIngredientSlot;
 import com.cleanroommc.multiblocked.api.gui.texture.IGuiTexture;
-import com.cleanroommc.multiblocked.util.Position;
-import com.cleanroommc.multiblocked.util.Size;
 import com.cleanroommc.multiblocked.api.gui.util.DrawerHelper;
 import com.cleanroommc.multiblocked.api.gui.util.TextFormattingUtil;
 import com.cleanroommc.multiblocked.api.gui.widget.Widget;
+import com.cleanroommc.multiblocked.util.Position;
+import com.cleanroommc.multiblocked.util.Size;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
@@ -115,7 +115,7 @@ public class TankWidget extends Widget implements IIngredientSlot {
             if (showTips) {
                 GlStateManager.pushMatrix();
                 GlStateManager.scale(0.5, 0.5, 1);
-                String s = TextFormattingUtil.formatLongToCompactString(lastFluidInTank.amount, 4) + "mb";
+                String s = TextFormattingUtil.formatLongToCompactStringBuckets(lastFluidInTank.amount, 3) + "B";
                 FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
                 fontRenderer.drawStringWithShadow(s, (pos.x + (size.width / 3f)) * 2 - fontRenderer.getStringWidth(s) + 21, (pos.y + (size.height / 3f) + 6) * 2, 0xFFFFFF);
                 GlStateManager.popMatrix();

--- a/src/main/java/com/cleanroommc/multiblocked/api/gui/widget/imp/recipe/ContentWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/api/gui/widget/imp/recipe/ContentWidget.java
@@ -19,13 +19,11 @@ import mezz.jei.api.gui.IGhostIngredientHandler.Target;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.resources.I18n;
-import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -184,7 +182,7 @@ public abstract class ContentWidget<T> extends SelectableWidgetGroup {
         if (chance < 1) {
             tooltipText += "\n" + (chance == 0 ?
                     LocalizationUtils.format("multiblocked.gui.content.chance_0") :
-                    LocalizationUtils.format("multiblocked.gui.content.chance_1", String.format("%.1f", chance * 100)));
+                    LocalizationUtils.format("multiblocked.gui.content.chance_1", String.format("%.1f", chance * 100) + "%%"));
         }
         if (perTick) {
             tooltipText += "\n" + LocalizationUtils.format("multiblocked.gui.content.per_tick");

--- a/src/main/java/com/cleanroommc/multiblocked/api/gui/widget/imp/recipe/ContentWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/api/gui/widget/imp/recipe/ContentWidget.java
@@ -19,6 +19,7 @@ import mezz.jei.api.gui.IGhostIngredientHandler.Target;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -186,7 +187,7 @@ public abstract class ContentWidget<T> extends SelectableWidgetGroup {
                     LocalizationUtils.format("multiblocked.gui.content.chance_1", String.format("%.1f", chance * 100)));
         }
         if (perTick) {
-            tooltipText += "\n" + LocalizationUtils.format("multiblocked.gui.content.tips.per_tick");
+            tooltipText += "\n" + LocalizationUtils.format("multiblocked.gui.content.per_tick");
         }
         super.setHoverTooltip(tooltipText);
         return this;
@@ -235,7 +236,7 @@ public abstract class ContentWidget<T> extends SelectableWidgetGroup {
         Size size = getSize();
         GlStateManager.scale(0.5, 0.5, 1);
         GlStateManager.disableDepth();
-        String s = chance == 0 ? "no cost" : String.format("%.1f", chance * 100) + "%";
+        String s = chance == 0 ? LocalizationUtils.format("multiblocked.gui.content.chance_0_short") : String.format("%.1f", chance * 100) + "%";
         int color = chance == 0 ? 0xff0000 : 0xFFFF00;
         FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
         fontRenderer.drawStringWithShadow(s, (pos.x + (size.width / 3f)) * 2 - fontRenderer.getStringWidth(s) + 23, (pos.y + (size.height / 3f) + 6) * 2 - size.height, color);
@@ -249,7 +250,7 @@ public abstract class ContentWidget<T> extends SelectableWidgetGroup {
             Size size = getSize();
             GlStateManager.scale(0.5, 0.5, 1);
             GlStateManager.disableDepth();
-            String s = "per tick";
+            String s = LocalizationUtils.format("multiblocked.gui.content.tips.per_tick_short");
             int color = 0xFFFF00;
             FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
             fontRenderer.drawStringWithShadow(s, (pos.x + (size.width / 3f)) * 2 - fontRenderer.getStringWidth(s) + 23, (pos.y + (size.height / 3f) + 6) * 2 - size.height + (chance == 1 ? 0 : 10), color);

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EMCProjectECapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EMCProjectECapability.java
@@ -71,7 +71,7 @@ public class EMCProjectECapability extends MultiblockCapability<Long> {
 
     @Override
     public ContentWidget<? super Long> createContentWidget() {
-        return new NumberContentWidget().setContentTexture(new TextTexture("EMC", color)).setUnit("emc");
+        return new NumberContentWidget().setContentTexture(new TextTexture("EMC", color)).setUnit("EMC");
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
@@ -1,25 +1,28 @@
 package com.cleanroommc.multiblocked.common.capability;
 
-import com.cleanroommc.multiblocked.api.capability.proxy.CapCapabilityProxy;
 import com.cleanroommc.multiblocked.api.capability.IO;
 import com.cleanroommc.multiblocked.api.capability.MultiblockCapability;
+import com.cleanroommc.multiblocked.api.capability.proxy.CapCapabilityProxy;
 import com.cleanroommc.multiblocked.api.capability.trait.CapabilityTrait;
 import com.cleanroommc.multiblocked.api.gui.texture.TextTexture;
 import com.cleanroommc.multiblocked.api.gui.widget.imp.recipe.ContentWidget;
 import com.cleanroommc.multiblocked.api.pattern.util.BlockInfo;
 import com.cleanroommc.multiblocked.api.recipe.Recipe;
 import com.cleanroommc.multiblocked.common.capability.trait.EnergyCapabilityTrait;
-import com.cleanroommc.multiblocked.common.capability.widget.NumberContentWidget;
+import com.cleanroommc.multiblocked.common.capability.widget.TieredNumberContentWidget;
 import com.google.gson.*;
+import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityEnergyHatch;
+import gregtech.integration.jei.utils.JEIHelpers;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.Loader;
 
 import javax.annotation.Nonnull;
@@ -58,7 +61,10 @@ public class EnergyGTCECapability extends MultiblockCapability<Long> {
 
     @Override
     public ContentWidget<? super Long> createContentWidget() {
-        return new NumberContentWidget().setContentTexture(new TextTexture("EU", color)).setUnit("EU");
+        return new TieredNumberContentWidget()
+                .setTierFunction(EU -> String.format(" (%s)", GTValues.VNF[JEIHelpers.getMinTierForVoltage(EU)] + TextFormatting.RESET))
+                .setContentTexture(new TextTexture("EU", color))
+                .setUnit("EU");
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/GPExtraUtilities2Capability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/GPExtraUtilities2Capability.java
@@ -12,15 +12,11 @@ import com.cleanroommc.multiblocked.api.registry.MbdComponents;
 import com.cleanroommc.multiblocked.api.tile.ComponentTileEntity;
 import com.cleanroommc.multiblocked.common.capability.trait.GPPlayerCapabilityTrait;
 import com.cleanroommc.multiblocked.common.capability.widget.NumberContentWidget;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
+import com.google.gson.*;
 import net.minecraft.tileentity.TileEntity;
 
 import javax.annotation.Nonnull;
-import java.awt.Color;
+import java.awt.*;
 import java.lang.reflect.Type;
 import java.util.List;
 
@@ -53,7 +49,7 @@ public class GPExtraUtilities2Capability extends MultiblockCapability<Float> {
 
     @Override
     public ContentWidget<? super Float> createContentWidget() {
-        return new NumberContentWidget().setContentTexture(new TextTexture("GP", color)).setUnit("gp");
+        return new NumberContentWidget().setContentTexture(new TextTexture("GP", color)).setUnit("GP");
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/ManaBotaniaCapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/ManaBotaniaCapability.java
@@ -1,24 +1,20 @@
 package com.cleanroommc.multiblocked.common.capability;
 
-import com.cleanroommc.multiblocked.api.capability.proxy.CapabilityProxy;
 import com.cleanroommc.multiblocked.api.capability.IO;
 import com.cleanroommc.multiblocked.api.capability.MultiblockCapability;
+import com.cleanroommc.multiblocked.api.capability.proxy.CapabilityProxy;
 import com.cleanroommc.multiblocked.api.gui.texture.TextTexture;
 import com.cleanroommc.multiblocked.api.gui.widget.imp.recipe.ContentWidget;
 import com.cleanroommc.multiblocked.api.pattern.util.BlockInfo;
 import com.cleanroommc.multiblocked.api.recipe.Recipe;
 import com.cleanroommc.multiblocked.common.capability.widget.NumberContentWidget;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
+import com.google.gson.*;
 import net.minecraft.tileentity.TileEntity;
 import vazkii.botania.api.mana.IManaReceiver;
 import vazkii.botania.common.block.ModBlocks;
 
 import javax.annotation.Nonnull;
-import java.awt.Color;
+import java.awt.*;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
@@ -52,7 +48,7 @@ public class ManaBotaniaCapability extends MultiblockCapability<Integer> {
 
     @Override
     public ContentWidget<? super Integer> createContentWidget() {
-        return new NumberContentWidget().setContentTexture(new TextTexture("MN", color)).setUnit("mana");
+        return new NumberContentWidget().setContentTexture(new TextTexture("MN", color)).setUnit("Mana");
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/GasStackWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/GasStackWidget.java
@@ -29,7 +29,7 @@ public class GasStackWidget extends ContentWidget<GasStack> {
     protected void onContentUpdate() {
         if (Multiblocked.isClient() && content != null) {
             this.setHoverTooltip(TextFormatting.AQUA + content.getGas().getLocalizedName() + TextFormatting.RESET + "\n" + LocalizationUtils
-                    .format("multiblocked.gui.trait.gas.amount") + " "  + + content.amount);
+                    .format("multiblocked.gui.trait.gas.amount") + " " + content.amount);
         }
     }
 
@@ -48,7 +48,7 @@ public class GasStackWidget extends ContentWidget<GasStack> {
             GlStateManager.enableBlend();
             drawGas(minecraft, pos.x + 1, pos.y + 1, content);
             GlStateManager.scale(0.5, 0.5, 1);
-            String s = TextFormattingUtil.formatLongToCompactString(content.amount, 4);
+            String s = TextFormattingUtil.formatLongToCompactStringBuckets(content.amount, 3) + "B";
             FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
             fontRenderer.drawStringWithShadow(s, (pos.x + (size.width / 3f)) * 2 - fontRenderer.getStringWidth(s) + 21, (pos.y + (size.height / 3f) + 6) * 2, 0xFFFFFF);
             GlStateManager.popMatrix();

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/ItemsContentWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/ItemsContentWidget.java
@@ -47,7 +47,7 @@ public class ItemsContentWidget extends ContentWidget<ItemsIngredient> {
                 if (chance < 1) {
                     l.add(chance == 0 ? LocalizationUtils.format("multiblocked.gui.content.chance_0") : LocalizationUtils.format("multiblocked.gui.content.chance_1", String.format("%.1f", chance * 100)));
                     if (perTick) {
-                        l.add(LocalizationUtils.format("multiblocked.gui.content.tips.per_tick"));
+                        l.add(LocalizationUtils.format("multiblocked.gui.content.per_tick"));
                     }
                 }
             }));

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/ParticleStackWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/ParticleStackWidget.java
@@ -29,7 +29,7 @@ public class ParticleStackWidget extends ContentWidget<ParticleStack> {
             String tips = Lang.localise(content.getParticle().getUnlocalizedName()) + '\n' +
                             TextFormatting.YELLOW + Lang.localise("gui.qmd.particlestack.amount", Units.getSIFormat(content.getAmount(), "pu")) + '\n' +
                             TextFormatting.DARK_GREEN + Lang.localise("gui.qmd.particlestack.mean_energy", Units.getParticleEnergy(content.getMeanEnergy())) + '\n' +
-                            TextFormatting.RED + Lang.localise("gui.qmd.particlestack.focus", Units.getSIFormat(content.getFocus(), "")) + '\n';
+                            TextFormatting.RED + Lang.localise("gui.qmd.particlestack.focus", Units.getSIFormat(content.getFocus(), ""));
             this.setHoverTooltip(tips);
         }
     }

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/TieredNumberContentWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/TieredNumberContentWidget.java
@@ -1,0 +1,23 @@
+package com.cleanroommc.multiblocked.common.capability.widget;
+
+import java.util.function.Function;
+
+public class TieredNumberContentWidget extends NumberContentWidget {
+
+    private Function<Long, String> tierFunction;
+
+    public TieredNumberContentWidget() {
+
+    }
+
+    @Override
+    protected void onContentUpdate() {
+        isDecimal = content instanceof Float || content instanceof Double;
+        this.setHoverTooltip(content + " " + unit + tierFunction.apply(content.longValue()));
+    }
+
+    public TieredNumberContentWidget setTierFunction(Function<Long, String> function) {
+        this.tierFunction = function;
+        return this;
+    }
+}

--- a/src/main/resources/assets/multiblocked/lang/en_us.lang
+++ b/src/main/resources/assets/multiblocked/lang/en_us.lang
@@ -186,7 +186,7 @@ multiblocked.gui.content.per_tick=§aConsumed Per Tick§r
 multiblocked.gui.content.tips.per_tick_short=§a/tick§r
 multiblocked.gui.content.chance_0=§cNot Consumed§r
 multiblocked.gui.content.chance_0_short=§cNC§r
-multiblocked.gui.content.chance_1=Chance:§e %s%%§r
+multiblocked.gui.content.chance_1=Chance: §e%s%%§r
 
 multiblocked.gui.trait.energy.progress=EU Stored: %d / %d
 multiblocked.gui.trait.energy.tips=Capability (EU)

--- a/src/main/resources/assets/multiblocked/lang/en_us.lang
+++ b/src/main/resources/assets/multiblocked/lang/en_us.lang
@@ -182,10 +182,11 @@ multiblocked.gui.dialogs.recipe_map.add_in=Add an Input Ingredient
 multiblocked.gui.dialogs.recipe_map.add_out=Add an Output Ingredient
 multiblocked.top.recipe_progress=Progress:
 
-multiblocked.gui.content.per_tick=Consume Per Tick
-multiblocked.gui.content.chance_0=§cno cost§r
-multiblocked.gui.content.chance_1=chance:§e %s %%§r
-multiblocked.gui.content.tips.per_tick=§aper tick§r
+multiblocked.gui.content.per_tick=§aConsumed Per Tick§r
+multiblocked.gui.content.tips.per_tick_short=§a/tick§r
+multiblocked.gui.content.chance_0=§cNot Consumed§r
+multiblocked.gui.content.chance_0_short=§cNC§r
+multiblocked.gui.content.chance_1=Chance:§e %s%%§r
 
 multiblocked.gui.trait.energy.progress=EU Stored: %d / %d
 multiblocked.gui.trait.energy.tips=Capability (EU)

--- a/src/main/resources/assets/multiblocked/lang/en_us.lang
+++ b/src/main/resources/assets/multiblocked/lang/en_us.lang
@@ -186,7 +186,7 @@ multiblocked.gui.content.per_tick=§aConsumed Per Tick§r
 multiblocked.gui.content.tips.per_tick_short=§a/tick§r
 multiblocked.gui.content.chance_0=§cNot Consumed§r
 multiblocked.gui.content.chance_0_short=§cNC§r
-multiblocked.gui.content.chance_1=Chance: §e%s%%§r
+multiblocked.gui.content.chance_1=§eChance: %s
 
 multiblocked.gui.trait.energy.progress=EU Stored: %d / %d
 multiblocked.gui.trait.energy.tips=Capability (EU)

--- a/src/main/resources/assets/multiblocked/lang/en_us.lang
+++ b/src/main/resources/assets/multiblocked/lang/en_us.lang
@@ -54,7 +54,7 @@ controller_tester.name=Controller Test Block
 controller_tester.description=You could use this block to test your scripts without restart game. It's unsafe, which can only be used in the single play.
 
 multiblocked.fluid.empty=Empty
-multiblocked.fluid.amount=§9Amount: %,d/%,d mb
+multiblocked.fluid.amount=§9Amount: %,d/%,d mB
 multiblocked.fluid.temperature=§cTemperature: %,d K
 multiblocked.fluid.state_gas=§aState: Gaseous
 multiblocked.fluid.state_liquid=§aState: Liquid
@@ -233,7 +233,7 @@ multiblocked.gui.label.configurator=no configurator
 multiblocked.gui.label.scale=Scale
 multiblocked.gui.label.light=Light
 multiblocked.gui.label.render_range=Render Range
-multiblocked.gui.label.tank_capability=Tank Capability (mb):
+multiblocked.gui.label.tank_capability=Tank Capability (mB):
 multiblocked.gui.label.amount=Amount:
 multiblocked.gui.label.number=Number:
 multiblocked.gui.label.energy=Energy:

--- a/src/main/resources/assets/multiblocked/lang/zh_cn.lang
+++ b/src/main/resources/assets/multiblocked/lang/zh_cn.lang
@@ -179,7 +179,7 @@ multiblocked.gui.dialogs.recipe_map.add_in=添加一个输入材料
 multiblocked.gui.dialogs.recipe_map.add_out=添加一个输出材料
 multiblocked.top.recipe_progress=进度:
 
-multiblocked.gui.content.per_tick=每 Tick 消耗
+multiblocked.gui.content.per_tick=§a每 Tick 消耗§r
 multiblocked.gui.content.chance_0=§c不消耗§r
 multiblocked.gui.content.chance_1=概率:§e %s %%§r
 multiblocked.gui.content.tips.per_tick=§a每 Tick§r


### PR DESCRIPTION
This PR improves tooltips and other similar information displays.

The "Not Consumed" slot display now shows as "NC" as to not go off the slot, with a hover tooltip providing more information.
![image](https://user-images.githubusercontent.com/37029404/164948544-52a2ec97-ebd6-40da-91f7-ef6ced511036.png)

For consumption per tick inputs, the slot display now shows as "/tick" as to not go off of the slot. The hover tootip provides similar information to non consumed inputs.
![image](https://user-images.githubusercontent.com/37029404/164948588-73a9091f-22e3-44fe-950b-c069216c6afc.png)

Translation keys have been added for both of the above.

GTEU now shows the appropriate voltage tier when used. 
![image](https://user-images.githubusercontent.com/37029404/164948600-f8e9771f-ebc9-4ffd-b29f-1d7893bf9f58.png)

The fluid slot display has been changed to use B when there is 1000 or more mB present, in order to prevent the amount from exceeding the slot boundaries. This has also been applied to mekanism gas inputs.
![image](https://user-images.githubusercontent.com/37029404/164948612-3bc0e305-141e-4d01-957d-2644cf7d52b5.png)
![image](https://user-images.githubusercontent.com/37029404/164948617-dce6e05f-068e-491a-92d7-4f439a65041c.png)

Numerous units have been changed to be consistent with their mods: `emc` -> `EMC`, `gp` -> `GP`, and `mana` -> `Mana`.

A Format Error has also been fixed that sometimes appeared on chances on QMD particlestacks.