### PR TITLE
Fix crash with GTCEu (#63)

### DIFF
--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
@@ -18,9 +18,9 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityEnergyHatch;
-import gregtech.integration.jei.utils.JEIHelpers;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -71,7 +71,7 @@ public class EnergyGTCECapability extends MultiblockCapability<Long> {
     public ContentWidget<? super Long> createContentWidget() {
         if (isCEu()) {
             return new TieredNumberContentWidget()
-                    .setTierFunction(EU -> String.format(" (%s)", GTValues.VNF[JEIHelpers.getMinTierForVoltage(EU)] + TextFormatting.RESET))
+                    .setTierFunction(EU -> String.format(" (%s)", GTValues.VNF[GTUtility.getTierByVoltage(EU)] + TextFormatting.RESET))
                     .setContentTexture(new TextTexture("EU", color))
                     .setUnit("EU");
         } else {


### PR DESCRIPTION
Fixes [crash](https://github.com/CleanroomMC/Multiblocked/issues/63) by switching from JEIHelpers.getMinTierForVoltage to GTUtility.getTierByVoltage