### PR TITLE
Fix GTCEu crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     deobfCompile "curse.maven:botania-225643:3330934"
     deobfCompile 'curse.maven:codechicken-lib-1-8-242818:2779848'
     deobfCompile 'curse.maven:extra-utilities-225561:2678374'
-    deobfCompile 'curse.maven:gregtech-ce-unofficial-557242:3745499'
+    deobfCompile 'curse.maven:gregtech-ce-unofficial-557242:4068926'
     deobfCompile "curse.maven:lightningcraft-237422:2872478"
     deobfCompile 'curse.maven:mcmultipart-239431:2615930'
     deobfCompile 'curse.maven:mekanism-268560:2835175'

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
@@ -18,9 +18,9 @@ import gregtech.api.GregTechAPI;
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.util.GTUtility;
 import gregtech.common.metatileentities.MetaTileEntities;
 import gregtech.common.metatileentities.multi.multiblockpart.MetaTileEntityEnergyHatch;
-import gregtech.integration.jei.utils.JEIHelpers;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -71,7 +71,7 @@ public class EnergyGTCECapability extends MultiblockCapability<Long> {
     public ContentWidget<? super Long> createContentWidget() {
         if (isCEu()) {
             return new TieredNumberContentWidget()
-                    .setTierFunction(EU -> String.format(" (%s)", GTValues.VNF[JEIHelpers.getMinTierForVoltage(EU)] + TextFormatting.RESET))
+                    .setTierFunction(EU -> String.format(" (%s)", GTValues.VNF[GTUtility.getTierByVoltage(EU)] + TextFormatting.RESET))
                     .setContentTexture(new TextTexture("EU", color))
                     .setUnit("EU");
         } else {


### PR DESCRIPTION
Fixes [crash](https://github.com/CleanroomMC/Multiblocked/issues/63) by switching from deprecated JEIHelpers.getMinTierForVoltage to GTUtility.getTierByVoltage