### PR TITLE
Add AE2 dependency as latest GTCEu version requires it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 
     compile 'zone.rong:mixinbooter:4.2'
 
+    compile 'curse.maven:ae2-extended-life-570458:4105092'
     compile 'software.bernie.geckolib:forge-1.12.2-geckolib:3.0.21'
     compile 'CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.673'
     compile 'mezz.jei:jei_1.12.2:4.15.0.293'


### PR DESCRIPTION
Latest version of GTCEu now requires AE2 to properly compile. Due to my oversight AE2 dependency wasn't included with fix, so i'm making this pull to fix that.