### PR TITLE
Correcting facing checks on GTCEu energy capabilities, primarily for dynamos.

### DIFF
--- a/src/main/java/com/cleanroommc/multiblocked/api/capability/MultiblockCapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/api/capability/MultiblockCapability.java
@@ -26,7 +26,10 @@ import stanhebben.zenscript.annotations.ZenProperty;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Used to detect whether a machine has a certain capability. And provide its capability in proxy {@link CapabilityProxy}.
@@ -137,6 +140,20 @@ public abstract class MultiblockCapability<T> implements JsonSerializer<T>, Json
             if (cap != null) return Collections.singleton(cap);
         }
         return found;
+    }
+
+    /**
+     * For blocks that only support a capability on limited sides, find the first supporting side.
+     */
+    @Nonnull
+    public final <C> EnumFacing getFrontFacing(Capability<C> capability, @Nonnull TileEntity tileEntity) {
+        for (EnumFacing facing : EnumFacing.VALUES) {
+            C cap = tileEntity.getCapability(capability, facing);
+            if (cap != null) {
+                return facing;
+            }
+        }
+        return EnumFacing.UP;
     }
 
     /**

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
@@ -12,7 +12,11 @@ import com.cleanroommc.multiblocked.api.recipe.Recipe;
 import com.cleanroommc.multiblocked.common.capability.trait.EnergyCapabilityTrait;
 import com.cleanroommc.multiblocked.common.capability.widget.NumberContentWidget;
 import com.cleanroommc.multiblocked.common.capability.widget.TieredNumberContentWidget;
-import com.google.gson.*;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
 import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
 import gregtech.api.capability.GregtechCapabilities;
@@ -64,7 +68,10 @@ public class EnergyGTCECapability extends MultiblockCapability<Long> {
 
     @Override
     public EnergyCapabilityProxy createProxy(@Nonnull IO io, @Nonnull TileEntity tileEntity) {
-        return new EnergyCapabilityProxy(tileEntity);
+        EnergyCapabilityProxy energyCapabilityProxy = new EnergyCapabilityProxy(tileEntity);
+        energyCapabilityProxy.facing = getFrontFacing(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, tileEntity);
+        System.out.println("TTT : setting facing to " + energyCapabilityProxy.facing);
+        return energyCapabilityProxy;
     }
 
     @Override
@@ -132,6 +139,16 @@ public class EnergyGTCECapability extends MultiblockCapability<Long> {
 
         public EnergyCapabilityProxy(TileEntity tileEntity) {
             super(EnergyGTCECapability.CAP, tileEntity, GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER);
+        }
+
+        @Override
+        public IEnergyContainer getCapability(@Nullable String slotName) {
+            IEnergyContainer tempCapability = super.getCapability(slotName);
+            if (tempCapability == null) {
+                // GTCEu dynamos only accept on one facing, and this could have been rotated
+                facing = EnergyGTCECapability.CAP.getFrontFacing(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, getTileEntity());
+            }
+            return super.getCapability(slotName);
         }
 
         @Override

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EnergyGTCECapability.java
@@ -70,7 +70,6 @@ public class EnergyGTCECapability extends MultiblockCapability<Long> {
     public EnergyCapabilityProxy createProxy(@Nonnull IO io, @Nonnull TileEntity tileEntity) {
         EnergyCapabilityProxy energyCapabilityProxy = new EnergyCapabilityProxy(tileEntity);
         energyCapabilityProxy.facing = getFrontFacing(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, tileEntity);
-        System.out.println("TTT : setting facing to " + energyCapabilityProxy.facing);
         return energyCapabilityProxy;
     }
 


### PR DESCRIPTION
Currently it is not possible to make a generator that produces EU power using GTCEu's multiblock dynamos. 

When checking for most capabilities, the default facing presumed is UP (ControllerTileEntity assumes this default). For tiles that accept capabilities on all sides, this is fine. Dynamos however only accept on one face, and can be rotated.

This change adds a facing correcting when checking for recipes to adjust the facing if it has been changed.