### PR TITLE
Fixed spelling mistake on recipe status GUI

### DIFF
--- a/src/main/resources/assets/multiblocked/lang/en_us.lang
+++ b/src/main/resources/assets/multiblocked/lang/en_us.lang
@@ -95,7 +95,7 @@ itemGroup.multiblocked=Multiblocked
 
 multiblocked.recipe.duration=Duration: %ds
 multiblocked.recipe.status.working=Status: §cWorking§r
-multiblocked.recipe.status.idle=sStatus: §aIdle§r
+multiblocked.recipe.status.idle=Status: §aIdle§r
 multiblocked.recipe.status.suspend=Status: §3Suspend§r
 multiblocked.recipe.remaining=Remaining time: %ds
 


### PR DESCRIPTION
Fixes a spelling mistake on the recipe progress GUI for multiblocks.

The issue in question:
![image](https://user-images.githubusercontent.com/33578674/230424904-a0e6f793-7801-4364-9756-e3195ce8d380.png)
