### PR TITLE
move from Embers-Rekindled to Embers Unofficial Extended Life

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     compileOnly 'curse.maven:project-e-226410:2702991'
     compileOnly 'curse.maven:blood-magic-224791:2822288'
     compileOnly 'curse.maven:guide-api-228832:2645992'
-    compileOnly 'curse.maven:embers-rekindled-300777:3695248'
+    compileOnly 'curse.maven:embers-extended-life-936489:5077562'
     compileOnly 'curse.maven:thaumic-augmentation-319441:3536155'
     compileOnly 'curse.maven:mystical-mechanics-300742:3006392'
     compileOnly 'me.desht.pneumaticcraft:pneumaticcraft-repressurized:1.12.2-0.11.9-384'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 org.gradle.jvmargs = -Xmx3G
 
 # Mod Information
-mod_version = 0.8.5
+mod_version = 0.8.6
 maven_group = com.cleanroommc
 archives_base_name = multiblocked
 

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EmberEmbersCapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EmberEmbersCapability.java
@@ -16,7 +16,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import net.minecraft.tileentity.TileEntity;
-import teamroots.embers.RegistryManager;
+import teamroots.embers.register.BlockRegister;
 import teamroots.embers.api.capabilities.EmbersCapabilities;
 import teamroots.embers.api.power.IEmberCapability;
 
@@ -63,12 +63,12 @@ public class EmberEmbersCapability extends MultiblockCapability<Double> {
     @Override
     public BlockInfo[] getCandidates() {
         return new BlockInfo[] {
-                BlockInfo.fromBlockState(RegistryManager.charger.getDefaultState()),
-                BlockInfo.fromBlockState(RegistryManager.copper_cell.getDefaultState()),
-                BlockInfo.fromBlockState(RegistryManager.ember_funnel.getDefaultState()),
-                BlockInfo.fromBlockState(RegistryManager.ember_siphon.getDefaultState()),
-                BlockInfo.fromBlockState(RegistryManager.ember_injector.getDefaultState()),
-                BlockInfo.fromBlockState(RegistryManager.ember_activator.getDefaultState())
+                BlockInfo.fromBlockState(BlockRegister.CHARGER.getDefaultState()),
+                BlockInfo.fromBlockState(BlockRegister.COPPER_CELL.getDefaultState()),
+                BlockInfo.fromBlockState(BlockRegister.EMBER_FUNNEL.getDefaultState()),
+                BlockInfo.fromBlockState(BlockRegister.EMBER_SIPHON.getDefaultState()),
+                BlockInfo.fromBlockState(BlockRegister.EMBER_INJECTOR.getDefaultState()),
+                BlockInfo.fromBlockState(BlockRegister.EMBER_ACTIVATOR.getDefaultState())
         };
     }
 

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/EmberEmbersCapability.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/EmberEmbersCapability.java
@@ -16,6 +16,9 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import teamroots.embers.Embers;
 import teamroots.embers.register.BlockRegister;
 import teamroots.embers.api.capabilities.EmbersCapabilities;
 import teamroots.embers.api.power.IEmberCapability;
@@ -63,12 +66,12 @@ public class EmberEmbersCapability extends MultiblockCapability<Double> {
     @Override
     public BlockInfo[] getCandidates() {
         return new BlockInfo[] {
-                BlockInfo.fromBlockState(BlockRegister.CHARGER.getDefaultState()),
-                BlockInfo.fromBlockState(BlockRegister.COPPER_CELL.getDefaultState()),
-                BlockInfo.fromBlockState(BlockRegister.EMBER_FUNNEL.getDefaultState()),
-                BlockInfo.fromBlockState(BlockRegister.EMBER_SIPHON.getDefaultState()),
-                BlockInfo.fromBlockState(BlockRegister.EMBER_INJECTOR.getDefaultState()),
-                BlockInfo.fromBlockState(BlockRegister.EMBER_ACTIVATOR.getDefaultState())
+                BlockInfo.fromBlockState(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Embers.MODID,"charger")).getDefaultState()),
+                BlockInfo.fromBlockState(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Embers.MODID,"copper_cell")).getDefaultState()),
+                BlockInfo.fromBlockState(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Embers.MODID,"ember_funnel")).getDefaultState()),
+                BlockInfo.fromBlockState(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Embers.MODID,"ember_siphon")).getDefaultState()),
+                BlockInfo.fromBlockState(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Embers.MODID,"ember_injector")).getDefaultState()),
+                BlockInfo.fromBlockState(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(Embers.MODID,"ember_activator")).getDefaultState())
         };
     }
 


### PR DESCRIPTION
Back in November 2023 I decided to fork Embers Rekindled as there was no sign that it will be maintained for 1.12 any time soon. After some refactoring I want to restore compatibility with multiblocked. This pull request simply reflects the registry changes.
This makes the mod incompatible with Embers-Rekindled not that it should be used anymore, but I wanted to mention it.