### PR TITLE
properly register ItemDurabilityMultiblockCapability

### DIFF
--- a/src/main/java/com/cleanroommc/multiblocked/api/registry/MbdCapabilities.java
+++ b/src/main/java/com/cleanroommc/multiblocked/api/registry/MbdCapabilities.java
@@ -45,6 +45,7 @@ public class MbdCapabilities {
         registerCapability(ITEM = ItemMultiblockCapability.CAP);
         registerCapability(FLUID = FluidMultiblockCapability.CAP);
         registerCapability(EntityMultiblockCapability.CAP);
+        registerCapability(ItemDurabilityMultiblockCapability.CAP);
         if (Loader.isModLoaded(Multiblocked.MODID_BOT)) {
             registerCapability(ManaBotaniaCapability.CAP);
         }

--- a/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/ItemsContentWidget.java
+++ b/src/main/java/com/cleanroommc/multiblocked/common/capability/widget/ItemsContentWidget.java
@@ -66,7 +66,9 @@ public class ItemsContentWidget extends ContentWidget<ItemsIngredient> {
     @Override
     public ItemsIngredient getJEIContent(Object content) {
         if (content instanceof ItemStack) {
-            return new ItemsIngredient(this.content.getAmount(), (ItemStack) content);
+            ItemStack stack = (ItemStack) content;
+            if (isDurability) stack.setItemDamage(OreDictionary.WILDCARD_VALUE);
+            return new ItemsIngredient(this.content.getAmount(), stack);
         }
         return null;
     }


### PR DESCRIPTION
very small PR that registers this capability, because the author forgot, and because I ran into this while implementing GrS Multiblocked integration.

Also makes it so when items are pulled into this capability from JEI, their metadata is set to 32767 by default, because otherwise damaged items can't be used in this recipe. This of course can be changed in the json file as usual.