### PR TITLE
Fix ControllerTileEntity not being registered in certain circunstancies

### DIFF
--- a/src/main/java/com/cleanroommc/multiblocked/CommonProxy.java
+++ b/src/main/java/com/cleanroommc/multiblocked/CommonProxy.java
@@ -65,8 +65,6 @@ public class CommonProxy {
         Multiblocked.LOGGER.info("init");
         // register recipe map
         RecipeMap.registerRecipeFromFile(Multiblocked.GSON, new File(Multiblocked.location, "recipe_map"));
-        // execute init handler
-        MbdComponents.executeInitHandler();
         // register ui
         UIFactory.register(TileEntityUIFactory.INSTANCE);
         // loadCT
@@ -165,7 +163,6 @@ public class CommonProxy {
         if (!useInterfaceTraits.isEmpty()) {
             Class<?> teClazz = new DynamicTileEntityGenerator(definition.location.getPath(), useInterfaceTraits, definition.clazz).generateClass();
             definition.setTileEntityClass(teClazz);
-            GameRegistry.registerTileEntity(((Class<TileEntity>) teClazz), definition.location);
         }
     }
 

--- a/src/main/java/com/cleanroommc/multiblocked/api/registry/MbdComponents.java
+++ b/src/main/java/com/cleanroommc/multiblocked/api/registry/MbdComponents.java
@@ -80,8 +80,6 @@ public class MbdComponents {
         }
     }
 
-    public static List<Runnable> handlers = new ArrayList<>();
-
     @SuppressWarnings("unchecked")
     public static <T extends ComponentDefinition> void registerComponentFromFile(File location, Class<T> clazz, BiConsumer<T, JsonObject> postHandler) {
         for (File file : Optional.ofNullable(location.listFiles((f, n) -> n.endsWith(".json"))).orElse(new File[0])) {
@@ -97,7 +95,7 @@ public class MbdComponents {
                 definition.fromJson(config);
                 registerComponent(definition);
                 if (postHandler != null) {
-                    handlers.add(()->postHandler.accept(definition, config));
+                    postHandler.accept(definition, config);
                 }
             } catch (Exception e) {
                 Multiblocked.LOGGER.error("error while loading the definition file {}", file.toString());
@@ -105,12 +103,6 @@ public class MbdComponents {
         }
 
     }
-
-    public static void executeInitHandler() {
-        handlers.forEach(Runnable::run);
-        handlers.clear();
-    }
-
 
     public static void registerNoNeedController(ItemStack catalyst, ControllerDefinition definition) {
         CATALYST_SET.add(catalyst.getItem());
@@ -151,7 +143,7 @@ public class MbdComponents {
             definition.fromJson(config);
             registerComponent(definition);
             if (postHandler != null) {
-                handlers.add(()->postHandler.accept(definition, config));
+                postHandler.accept(definition, config);
             }
         } catch (Exception e) {
             Multiblocked.LOGGER.error("error while loading the definition resource {}", location.toString());


### PR DESCRIPTION
Due to load order, Map iteration order, and how TE registry are handled in certain cases the ControllerTileEntity can end up not being registered.

Multiblocked controllers with traits gets a ASM'd class TileEntity of their own.
But, are loaded from the json with ControllerTileEntity as their class.
They then are added to the DEFINITION_REGISTRY.
The DEFINITION_REGISTRY is then iterated on the Block registration event and the TE's are registered, using the TE class as a key for blacklisting.

BUT: the ASM'd TE classes are assigned in a later pass (FMLInitializationEvent)
which causes the original ControllerTileEntity to get the erased from the registry when the controller with the ASM'd class is added later.